### PR TITLE
Fixes issue #37 : fixes the css cursor property on yearlist buttons

### DIFF
--- a/src/assets/vendor/bootstrap/css/bootstrap.css
+++ b/src/assets/vendor/bootstrap/css/bootstrap.css
@@ -683,6 +683,9 @@ progress {
   padding-left: calc(var(--bs-gutter-x) * 0.5);
   margin-top: var(--bs-gutter-y);
 }
+.row #year-list a{
+  cursor: pointer;
+}
 
 .col {
   flex: 1 0 0%;


### PR DESCRIPTION
Fixes: #37

This PR addresses a bug where the cursor property wasn't functioning correctly when hovering over buttons in the yearlist, such as "first year," "second year," etc.

The bug caused the cursor property to only work on the first button. This PR resolves that issue.